### PR TITLE
Changed apertype files to octagons

### DIFF
--- a/aperture/aperture_upgrade_IT.madx
+++ b/aperture/aperture_upgrade_IT.madx
@@ -1,15 +1,3 @@
-write_OCTAGON(xx1,yy1,xx2,yy2): macro = {
- printf,text=" %g  %g",value=xx1,yy1;
- printf,text=" %g  %g",value=xx2,yy2;
- printf,text="-%g  %g",value=xx2,yy2;
- printf,text="-%g  %g",value=xx1,yy1;
- printf,text="-%g -%g",value=xx1,yy1;
- printf,text="-%g -%g",value=xx2,yy2;
- printf,text=" %g -%g",value=xx2,yy2;
- printf,text=" %g -%g",value=xx1,yy1;
- printf,text=" %g  %g",value=xx1,yy1;
-};
-
 aperture_def(eee,ttt,ap1,ap2,ap3,ap4,rtol,htol,vtol): macro={
 eeeL1,APERTYPE=ttt,APERTURE:={ap1,ap2,ap3,ap4},APER_TOL:={rtol,htol,vtol};
 eeeR1,APERTYPE=ttt,APERTURE:={ap1,ap2,ap3,ap4},APER_TOL:={rtol,htol,vtol};
@@ -41,18 +29,9 @@ if (bs_type == OCTA2015) {
   r_Q1=sqrt((sqrt(2)*r1_Q1-r2_Q1)^2+r2_Q1^2)/1e3;
   g_Q1=r1_Q1/1e3;
   hv_Q1=r1_Q1/1e3;
-  angle1_Q1=45-acos(g_Q1/r_Q1)/pi*180; !22.5 regular octagon
-  angle2_Q1=90-angle1_Q1;
+  angle1_q1=pi/4-acos(g_Q1/r_Q1);
+  angle2_q1=pi/2-angle1_q1;
   value,r_Q1,g_Q1,angle1_Q1,angle2_Q1;
-  xx1=r_Q1*cos(angle1_Q1/180*pi);!conversion to m
-  yy1=r_Q1*sin(angle1_Q1/180*pi);
-  xx2=r_Q1*cos(angle2_Q1/180*pi);
-  yy2=r_Q1*sin(angle2_Q1/180*pi);
-  value,xx1,yy1,xx2,yy2;
-  system, "rm  -f q1_aperture";
-  assign, echo="q1_aperture";
-  exec,write_OCTAGON(xx1,yy1,xx2,yy2);
-  assign, echo=terminal;
 
   !r1_Q23=114/2-1.5*(1-no_bs_tol); !C. Garion 9/5/2015 1.5 mech tol
   !r2_Q23=122/2-1.5*(1-no_bs_tol); !C. Garion 9/5/2015 1.5 mech tol
@@ -61,20 +40,9 @@ if (bs_type == OCTA2015) {
   r_Q23=sqrt((sqrt(2)*r1_Q23-r2_Q23)^2+r2_Q23^2)/1e3;
   g_Q23=r1_Q23/1e3;
   hv_Q23=r2_Q23/1e3;
-  angle1_Q23=45-acos(g_Q23/r_Q23)/pi*180; !22.5 regular octagon
-  angle2_Q23=90-angle1_Q23;
+  angle1_q23=pi/4-acos(g_Q23/r_Q23);
+  angle2_q23=pi/2-angle1_q23;
   value,r_Q23,g_Q23,angle1_Q23,angle2_Q23;
-  xx1=r_Q23*cos(angle1_Q23/180*pi);!conversion to m
-  yy1=r_Q23*sin(angle1_Q23/180*pi);
-  xx2=r_Q23*cos(angle2_Q23/180*pi);
-  yy2=r_Q23*sin(angle2_Q23/180*pi);
-  value,xx1,yy1,xx2,yy2;
-
-  system, "rm  -f q23_aperture";
-  assign, echo="q23_aperture";
-  exec,write_OCTAGON(xx1,yy1,xx2,yy2);
-  assign, echo=terminal;
-
 };
 
 !r_TAS   := 0.0270;     ! was 24 mm in slhcv1 and 25 mm in slhcv2 and 30 mm in slhc3, hllhc1.1
@@ -96,33 +64,33 @@ r_tol_D1 :=0.0006; h_tol_D1 :=0.0010+h_tol_D1_mod; v_tol_D1 :=0.0010+v_tol_D1_mo
 
 exec, aperture_def(TAXS.1  , rectellipse , r_TAS, r_TAS, r_TAS     , r_TAS     , r_tol_TAS, h_tol_TAS, v_tol_TAS);
 
-exec, aperture_def(MQXFA.A1, q1_aperture , hv_q1 , hv_q1 , angle1_q1 , angle2_q1 , r_tol_Q1 , h_tol_Q1 , v_tol_Q1);
-exec, aperture_def(MQXFA.B1, q1_aperture , hv_q1 , hv_q1 , angle1_q1 , angle2_q1 , r_tol_Q1 , h_tol_Q1 , v_tol_Q1);
+exec, aperture_def(MQXFA.A1,   OCTAGON, hv_q1 , hv_q1 , angle1_q1 , angle2_q1 , r_tol_Q1 , h_tol_Q1 , v_tol_Q1);
+exec, aperture_def(MQXFA.B1,   OCTAGON, hv_q1 , hv_q1 , angle1_q1 , angle2_q1 , r_tol_Q1 , h_tol_Q1 , v_tol_Q1);
 
-exec, aperture_def(MQXFB.A2, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2 , h_tol_Q2 , v_tol_Q2);
-exec, aperture_def(MQXFB.B2, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2 , h_tol_Q2 , v_tol_Q2);
+exec, aperture_def(MQXFB.A2,   OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2 , h_tol_Q2 , v_tol_Q2);
+exec, aperture_def(MQXFB.B2,   OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2 , h_tol_Q2 , v_tol_Q2);
 
-exec, aperture_def(MQXFA.A3, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3 , h_tol_Q3 , v_tol_Q3);
-exec, aperture_def(MQXFA.B3, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3 , h_tol_Q3 , v_tol_Q3);
+exec, aperture_def(MQXFA.A3,   OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3 , h_tol_Q3 , v_tol_Q3);
+exec, aperture_def(MQXFA.B3,   OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3 , h_tol_Q3 , v_tol_Q3);
 
-exec, aperture_def(MCBXFBH.A2, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
-exec, aperture_def(MCBXFBV.A2, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
-exec, aperture_def(MCBXFBH.B2, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
-exec, aperture_def(MCBXFBV.B2, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
+exec, aperture_def(MCBXFBH.A2, OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
+exec, aperture_def(MCBXFBV.A2, OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
+exec, aperture_def(MCBXFBH.B2, OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
+exec, aperture_def(MCBXFBV.B2, OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
 
-exec, aperture_def(MCBXFAV.3, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCBXFAH.3, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MQSXF.3  , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCSXF.3  , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCTXF.3  , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCTSXF.3 , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCSSXF.3 , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCOSXF.3 , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCOXF.3  , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCDSXF.3 , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCDXF.3  , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCBXFAV.3,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCBXFAH.3,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MQSXF.3  ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCSXF.3  ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCTXF.3  ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCTSXF.3 ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCSSXF.3 ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCOSXF.3 ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCOXF.3  ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCDSXF.3 ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCDXF.3  ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
 
-exec, aperture_def(MBXF.4   , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_D1, h_tol_D1, v_tol_D1);
+exec, aperture_def(MBXF.4   ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_D1, h_tol_D1, v_tol_D1);
 
 exec, aperture_2in1_def(BPMSQW.1 , rectellipse, r_BPMSQW, r_BPMSQW, r_BPMSQW, r_BPMSQW, r_tol_BPM, h_tol_BPM, v_tol_BPM);
 exec, aperture_2in1_def(BPMSQ.1  , rectellipse, r_BPMSQ , r_BPMSQ , r_BPMSQ , r_BPMSQ , r_tol_BPM, h_tol_BPM, v_tol_BPM);

--- a/aperture/aperture_upgrade_MS.madx
+++ b/aperture/aperture_upgrade_MS.madx
@@ -20,18 +20,6 @@
 
 ! Macros
 
-write_OCTAGON(xx1,yy1,xx2,yy2): macro = {
- printf,text=" %g  %g",value=xx1,yy1;
- printf,text=" %g  %g",value=xx2,yy2;
- printf,text="-%g  %g",value=xx2,yy2;
- printf,text="-%g  %g",value=xx1,yy1;
- printf,text="-%g -%g",value=xx1,yy1;
- printf,text="-%g -%g",value=xx2,yy2;
- printf,text=" %g -%g",value=xx2,yy2;
- printf,text=" %g -%g",value=xx1,yy1;
- printf,text=" %g  %g",value=xx1,yy1;
-};
-
 aperture_2in1_def(eee,ttt,ap1,ap2,ap3,ap4,rtol,htol,vtol): macro={
 eeeL1.B1,APERTYPE=ttt,APERTURE:={ap1,ap2,ap3,ap4},APER_TOL:={rtol,htol,vtol};
 eeeR1.B1,APERTYPE=ttt,APERTURE:={ap1,ap2,ap3,ap4},APER_TOL:={rtol,htol,vtol};
@@ -77,26 +65,13 @@ r_D2=sqrt((sqrt(2)*r1_D2-r2_D2)^2+r2_D2^2)/1e3;
 g_D2=r1_D2/1e3;
 hv_D2=r2_D2/1e3;
 
-angle1_D2=45-acos(g_d2/r_d2)/pi*180; !22.5 regular octagon
-angle2_D2=90-angle1_D2;
+angle1_D2=pi/4-acos(g_d2/r_d2); !22.5 regular octagon
+angle2_D2=pi/2-angle1_D2;
 
 value,r_D2,g_D2,angle1_D2,angle2_D2;
 
-xx1=r_D2*cos(angle1_D2/180*pi);!conversion to m
-yy1=r_D2*sin(angle1_D2/180*pi);
-xx2=r_D2*cos(angle2_D2/180*pi);
-yy2=r_D2*sin(angle2_D2/180*pi);
-
-value,xx1,yy1,xx2,yy2;
-
-system,"rm d2_aperture";assign, echo="d2_aperture";
-exec,write_OCTAGON(xx1,yy1,xx2,yy2);
-assign, echo=terminal;
-
-exec,aperture_2in1_def(MBRD.4,d2_aperture,
-          hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_D2, h_tol_D2, v_tol_D2);
-exec,aperture_2in1_def(TCLMA.4,d2_aperture,
-          hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_D2, h_tol_D2, v_tol_D2);
+exec,aperture_2in1_def(MBRD.4, OCTAGON,hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_D2,h_tol_D2,v_tol_D2);
+exec,aperture_2in1_def(TCLMA.4,OCTAGON,hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_D2,h_tol_D2,v_tol_D2);
 
 ! big corrector for crabs
 !g_MC2=0.037000;r_MC2=0.042000; !equal to D2 for the time being
@@ -104,10 +79,8 @@ exec,aperture_2in1_def(TCLMA.4,d2_aperture,
 !g_MC2=g_D2;r_MC2=r_D2; !equal to D2 for the time being
 !r_tol_MC2 =r_tol_D2; h_tol_MC2 :=h_tol_D2+h_tol_MC2_mod; v_tol_MC2 :=v_tol_D2+v_tol_MC2_mod;
 
-exec,aperture_2in1_def(MCBRDH.4,d2_aperture,
-          hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_D2 , h_tol_D2 , v_tol_D2);
-exec,aperture_2in1_def(MCBRDV.4,d2_aperture,
-          hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_D2 , h_tol_D2 , v_tol_D2);
+exec,aperture_2in1_def(MCBRDH.4,OCTAGON,hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_D2,h_tol_D2,v_tol_D2);
+exec,aperture_2in1_def(MCBRDV.4,OCTAGON,hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_D2,h_tol_D2,v_tol_D2);
 
 
 
@@ -183,26 +156,12 @@ r_q4=sqrt((sqrt(2)*r1_q4-r2_q4)^2+r2_q4^2)/1e3;
 g_q4=r1_q4/1e3;
 hv_q4=r2_q4/1e3;
 
-
-angle1_q4=45-acos(g_q4/r_q4)/pi*180; !22.5 regular octagon
-angle2_q4=90-angle1_q4;
+angle1_q4=pi/4-acos(g_q4/r_q4); !22.5 regular octagon
+angle2_q4=pi/2-angle1_q4;
 
 value,r_q4,g_q4,angle1_q4,angle2_q4;
 
-xx1=r_q4*cos(angle1_q4/180*pi);!conversion to m
-yy1=r_q4*sin(angle1_q4/180*pi);
-xx2=r_q4*cos(angle2_q4/180*pi);
-yy2=r_q4*sin(angle2_q4/180*pi);
-
-value,xx1,yy1,xx2,yy2;
-
-system,"rm q4_aperture";assign, echo="q4_aperture";
-exec,write_OCTAGON(xx1,yy1,xx2,yy2);
-assign, echo=terminal;
-
-
-exec,aperture_2in1_def(MQYY.4,q4_aperture,
-          hv_q4,hv_q4,angle1_q4,angle2_q4,r_tol_q4, h_tol_q4, v_tol_q4);
+exec,aperture_2in1_def(MQYY.4,OCTAGON,hv_q4,hv_q4,angle1_q4,angle2_q4,r_tol_q4,h_tol_q4,v_tol_q4);
 
 ! big corrector for crabs
 !g_MC2=0.037000;r_MC2=0.042000; !equal to q4 for the time being
@@ -210,10 +169,8 @@ exec,aperture_2in1_def(MQYY.4,q4_aperture,
 !g_MC2=g_q4;r_MC2=r_q4; !equal to q4 for the time being
 !r_tol_MC2 =r_tol_q4; h_tol_MC2 :=h_tol_q4+h_tol_MC2_mod; v_tol_MC2 :=v_tol_q4+v_tol_MC2_mod;
 
-exec,aperture_2in1_def(MCBYYH.4,q4_aperture,
-          hv_q4,hv_q4,angle1_q4,angle2_q4,r_tol_q4 , h_tol_q4 , v_tol_q4);
-exec,aperture_2in1_def(MCBYYV.4,q4_aperture,
-          hv_q4,hv_q4,angle1_q4,angle2_q4,r_tol_q4 , h_tol_q4 , v_tol_q4);
+exec,aperture_2in1_def(MCBYYH.4,OCTAGON,hv_q4,hv_q4,angle1_q4,angle2_q4,r_tol_q4,h_tol_q4,v_tol_q4);
+exec,aperture_2in1_def(MCBYYV.4,OCTAGON,hv_q4,hv_q4,angle1_q4,angle2_q4,r_tol_q4,h_tol_q4,v_tol_q4);
 
 
 !Q5  NOMINAL B.S ORIENTATION


### PR DESCRIPTION
This replaces the apertype files for D2, Q1, Q2, Q3 and Q4 with octagon apertypes.
The angles were also set in degrees for values aper_3 and aper_4. They should be in radians.